### PR TITLE
Preview version: Fix execution income expressed as fiat in income chart

### DIFF
--- a/src/frontend_vue/src/components/outputs/IncomeChart.vue
+++ b/src/frontend_vue/src/components/outputs/IncomeChart.vue
@@ -181,7 +181,7 @@ export default {
           },
           {
             label: `Execution Layer Income [${this.showIncomeInFiat ? this.currency : "ETH"}]`,
-            data: executionLayerData.map(d => d[0] as number),
+            data: this.showIncomeInFiat ? executionLayerData.map(d => d[1]) : executionLayerData.map(d => d[0] as number),
             backgroundColor: CHART_COLORS[6],
             type: 'bar',
           },


### PR DESCRIPTION
Hey, I noticed that execution rewards aren't converted to fiat upon toggling currency in the income chart ("Show income in ..."). This is using the currently deployed https://ethstaker.tax/preview. This should help, but I didn't manage to run and verify the change locally.